### PR TITLE
Add OpenAI translation game service

### DIFF
--- a/src/main/java/org/example/translation_game/controller/GameController.java
+++ b/src/main/java/org/example/translation_game/controller/GameController.java
@@ -1,7 +1,37 @@
 package org.example.translation_game.controller;
 
-import org.springframework.stereotype.Controller;
+import org.example.translation_game.model.User;
+import org.example.translation_game.service.GameService;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
+@RequestMapping("/game")
 public class GameController {
+
+    private final GameService gameService;
+
+    public GameController(GameService gameService) {
+        this.gameService = gameService;
+    }
+
+    /** Start a new game with the given number of rounds. */
+    @PostMapping("/start")
+    public String startGame(@RequestParam(defaultValue = "3") int rounds) {
+        gameService.startGame(rounds);
+        return gameService.nextSentence();
+    }
+
+    /** Get the next sentence for translation. */
+    @GetMapping("/sentence")
+    public String nextSentence() {
+        return gameService.nextSentence();
+    }
+
+    /** Submit a translation for the current sentence. */
+    @PostMapping("/translate")
+    public int submit(@RequestParam long userId, @RequestParam String text) {
+        User user = new User();
+        user.setUserId(userId);
+        return gameService.submitTranslation(user, text);
+    }
 }

--- a/src/main/java/org/example/translation_game/model/Score.java
+++ b/src/main/java/org/example/translation_game/model/Score.java
@@ -1,0 +1,29 @@
+package org.example.translation_game.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "score")
+@Getter
+@Setter
+@SequenceGenerator(
+        name = "SCORE_SEQ_GEN",
+        sequenceName = "SCORE_SEQ",
+        initialValue = 1,
+        allocationSize = 1
+)
+public class Score {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SCORE_SEQ_GEN")
+    @Column(name = "scoreId")
+    private Long scoreId;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @Column(name = "value")
+    private int value;
+}

--- a/src/main/java/org/example/translation_game/repository/ScoreRepository.java
+++ b/src/main/java/org/example/translation_game/repository/ScoreRepository.java
@@ -1,0 +1,9 @@
+package org.example.translation_game.repository;
+
+import org.example.translation_game.model.Score;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScoreRepository extends JpaRepository<Score, Long> {
+}

--- a/src/main/java/org/example/translation_game/service/GameService.java
+++ b/src/main/java/org/example/translation_game/service/GameService.java
@@ -1,0 +1,64 @@
+package org.example.translation_game.service;
+
+import org.example.translation_game.model.Score;
+import org.example.translation_game.model.User;
+import org.example.translation_game.repository.ScoreRepository;
+import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class GameService {
+
+    private final OpenAIService openAIService;
+    private final ScoreRepository scoreRepository;
+
+    private int totalRounds = 1;
+    private int currentRound = 0;
+    private String currentSentence;
+    private final Map<Long, Integer> scoreboard = new HashMap<>();
+
+    public GameService(OpenAIService openAIService, ScoreRepository scoreRepository) {
+        this.openAIService = openAIService;
+        this.scoreRepository = scoreRepository;
+    }
+
+    public void startGame(int rounds) {
+        this.totalRounds = rounds;
+        this.currentRound = 0;
+        scoreboard.clear();
+        this.currentSentence = null;
+    }
+
+    public String nextSentence() {
+        if (currentRound >= totalRounds) {
+            return null;
+        }
+        currentSentence = openAIService.generateSentence();
+        currentRound++;
+        return currentSentence;
+    }
+
+    public int submitTranslation(User user, String translation) {
+        if (currentSentence == null) {
+            return 0;
+        }
+        int score = openAIService.scoreTranslation(currentSentence, translation);
+        scoreboard.merge(user.getUserId(), score, Integer::sum);
+        if (currentRound >= totalRounds) {
+            saveScores();
+        }
+        return score;
+    }
+
+    private void saveScores() {
+        for (Map.Entry<Long, Integer> entry : scoreboard.entrySet()) {
+            Score score = new Score();
+            User user = new User();
+            user.setUserId(entry.getKey());
+            score.setUser(user);
+            score.setValue(entry.getValue());
+            scoreRepository.save(score);
+        }
+    }
+}

--- a/src/main/java/org/example/translation_game/service/OpenAIService.java
+++ b/src/main/java/org/example/translation_game/service/OpenAIService.java
@@ -1,8 +1,86 @@
 package org.example.translation_game.service;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.HashMap;
+import java.util.Map;
 
-//openai api 호출하는 api
 @Service
 public class OpenAIService {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * Generate a random English sentence using OpenAI ChatGPT model.
+     */
+    public String generateSentence() {
+        String prompt = "Generate a short random English sentence.";
+        Map<String, Object> request = buildChatRequest(prompt);
+        Map<?,?> response = postToOpenAI(request);
+        return extractContent(response);
+    }
+
+    /**
+     * Score the given Korean translation for the provided English sentence.
+     * Returns an integer score between 0 and 100.
+     */
+    public int scoreTranslation(String english, String korean) {
+        String prompt = "Score the quality of the following Korean translation " +
+                "for the given English sentence on a scale of 0 to 100. " +
+                "Respond with only the numeric score.\n" +
+                "English: " + english + "\n" +
+                "Korean: " + korean;
+        Map<String, Object> request = buildChatRequest(prompt);
+        Map<?,?> response = postToOpenAI(request);
+        String content = extractContent(response);
+        try {
+            return Integer.parseInt(content.trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private Map<String, Object> buildChatRequest(String prompt) {
+        Map<String, Object> message = new HashMap<>();
+        message.put("role", "user");
+        message.put("content", prompt);
+        Map<String, Object> request = new HashMap<>();
+        request.put("model", "gpt-3.5-turbo");
+        request.put("messages", new Map[]{ message });
+        return request;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<?,?> postToOpenAI(Map<String, Object> body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+        return restTemplate.postForObject("https://api.openai.com/v1/chat/completions", entity, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractContent(Map<?,?> response) {
+        if (response == null) return "";
+        Object choices = response.get("choices");
+        if (choices instanceof Iterable<?> iterable) {
+            for (Object c : iterable) {
+                if (c instanceof Map<?,?> map) {
+                    Object message = map.get("message");
+                    if (message instanceof Map<?,?> m) {
+                        Object content = m.get("content");
+                        if (content != null) return content.toString();
+                    }
+                }
+            }
+        }
+        return "";
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.application.name=TranslationGame
 #server.port=8080
+# OpenAI API key (set your own key in production)
+openai.api.key=


### PR DESCRIPTION
## Summary
- integrate a basic translation game service
- call OpenAI for random sentences and scoring translations
- expose `/game` REST endpoints for start/sentence/translate
- store user scores with new `Score` entity
- document OpenAI API key property

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0e814608328b70cf8d25f2d8c34